### PR TITLE
feat(prod): Adds promote to prod GCB config, updates README, uses GA …

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
-# spinnaker-telemetry
+# Spinnaker Stats Service
 
-Test cloudbuild 2
+This is the service that collects telemetry data from customer Spinnaker instances.
+
+This data helps the project maintainers and community decide where to focus our efforts and gauge how the product is being used in the wild.
+
+You can find aggregations and analysis of the collected data [here](TODO). For access to the raw data, you should be a contributing member of the community, and can request access by ... TODO.
 
 
-Report:
 
-<iframe width="600" height="450" src="https://datastudio.google.com/embed/reporting/1XEi3JH3FsbZRhAj3L6izC40os80VlaS5/page/1Mtw" frameborder="0" style="border:0" allowfullscreen></iframe>
+## Development
+
+All commits to the `master` branch are deployed to a staging environment hosted at https://stats-staging.spinnaker.io. See [cloudbuild-deploy-staging.yaml](./cloudbuild-deploy-staging.yaml).
+
+Deploying to production simply promotes the staging container to the production environment. See [cloudbuild-promote-staging-to-prod.yaml](cloudbuild-promote-staging-to-prod.yaml).

--- a/cloudbuild-deploy-staging.yaml
+++ b/cloudbuild-deploy-staging.yaml
@@ -3,13 +3,13 @@ steps:
   args: ['build',
          '-t', 'gcr.io/$PROJECT_ID/$REPO_NAME:$SHORT_SHA',
          '-t', 'gcr.io/$PROJECT_ID/$REPO_NAME:latest',
+         '-t', 'gcr.io/$PROJECT_ID/$REPO_NAME:staging',
          '.']
 - name: 'gcr.io/cloud-builders/docker'
   args: ['push',
          'gcr.io/$PROJECT_ID/$REPO_NAME:$SHORT_SHA']
 - name: 'gcr.io/cloud-builders/gcloud'
-  args: ['beta',
-         'run',
+  args: ['run',
          'deploy', '$_SERVICE_NAME',
          '--image', 'gcr.io/$PROJECT_ID/$REPO_NAME:$SHORT_SHA',
          '--region', '$_REGION',
@@ -25,3 +25,4 @@ substitutions:
 images:
 - gcr.io/$PROJECT_ID/$REPO_NAME:$SHORT_SHA
 - gcr.io/$PROJECT_ID/$REPO_NAME:latest
+- gcr.io/$PROJECT_ID/$REPO_NAME:staging

--- a/cloudbuild-promote-staging-to-prod.yaml
+++ b/cloudbuild-promote-staging-to-prod.yaml
@@ -1,0 +1,34 @@
+steps:
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['pull',
+           'gcr.io/$PROJECT_ID/$REPO_NAME:$_SOURCE_TAG']
+
+  - name: 'gcr.io/cloud-builders/curl'
+    entrypoint: /bin/bash
+    args:
+      - -c
+      - docker images --format "{{.Digest}}" > /workspace/sourceDigest
+
+  - name: 'gcr.io/cloud-builders/gcloud'
+    args: ['run',
+           'deploy', '$_SERVICE_NAME',
+           '--image', 'gcr.io/$PROJECT_ID/$REPO_NAME:`echo /workspace/sourceDigest`',
+           '--region', '$_REGION',
+           '--platform', '$_PLATFORM',
+           '--set-env-vars', 'GCP_PROJECT=$PROJECT_ID,LOG_ID_ENV=PROD',
+           '--quiet']
+
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['tag',
+           'gcr.io/$PROJECT_ID/$REPO_NAME:$_SOURCE_TAG',
+           'gcr.io/$PROJECT_ID/$REPO_NAME:$_DEST_TAG']
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['push',
+           'gcr.io/$PROJECT_ID/$REPO_NAME:$_DEST_TAG']
+
+substitutions:
+  _SOURCE_TAG: staging
+  _DEST_TAG: prod
+  _SERVICE_NAME: stats-prod-us-central1
+  _REGION: us-central1
+  _PLATFORM: managed


### PR DESCRIPTION
…gcloud run commands.

A corresponding GCB trigger has been created that will execute the build whenever someone creates a release through GH (and tags that release with a valid semantic version, i.e. `1.0.0`). The process will take whatever container is currently labeled `staging`, push it to the prod environment, then change the label upon success. 