### PR TITLE
chore(kork): Bump kork version due to log.proto update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway v1.12.1 // indirect
 	github.com/mitchellh/protoc-gen-go-json v0.0.0-20190813154521-ece073100ced // indirect
 	github.com/oklog/ulid/v2 v2.0.2
-	github.com/spinnaker/kork v6.18.1+incompatible // indirect
+	github.com/spinnaker/kork v7.21.1+incompatible // indirect
 	google.golang.org/genproto v0.0.0-20191115221424-83cc0476cb11 // indirect
 	gopkg.in/yaml.v2 v2.2.7 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,7 @@ github.com/spinnaker/kork v6.18.0+incompatible h1:frZ+BrMsc/G1S0G5kO24Ccv+AttCbN
 github.com/spinnaker/kork v6.18.0+incompatible/go.mod h1:yqMWgygneiV6aOHzjSfyrLguxpv6jMkL2v4f7jjpP6o=
 github.com/spinnaker/kork v6.18.1+incompatible h1:wc8GkGN3ngo2gSf+QF8gccT7hoSEdGDMOmp9lOi+NwE=
 github.com/spinnaker/kork v6.18.1+incompatible/go.mod h1:yqMWgygneiV6aOHzjSfyrLguxpv6jMkL2v4f7jjpP6o=
+github.com/spinnaker/kork v7.21.1+incompatible/go.mod h1:yqMWgygneiV6aOHzjSfyrLguxpv6jMkL2v4f7jjpP6o=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=


### PR DESCRIPTION
This is a follow-up to spinnaker/kork#503 and spinnaker/echo#770 where we added deploy method and version

cc @ttomsu 